### PR TITLE
Move to ubuntu-24.04 runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       plugin_name: wazuh-indexer-reports-scheduler
     steps:

--- a/.github/workflows/reports-scheduler-test-and-build-workflow.yml
+++ b/.github/workflows/reports-scheduler-test-and-build-workflow.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         java:
           - 21
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
       # this image tag is subject to change as more dependencies and updates will arrive over time


### PR DESCRIPTION
### Description
This PR modifies all references to the GHA `ubuntu-latest` runner to `ubuntu-24.04`.

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/578

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
