### PR TITLE
Clean up code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add repository bumper [(#43)](https://github.com/wazuh/wazuh-indexer-plugins/pull/43) 
 - Add scripts to check the opensearch and product version [(#59)](https://github.com/wazuh/wazuh-indexer-reporting/pull/59)
 - Add documentation to bring up an SMTP server for development [(#60)](https://github.com/wazuh/wazuh-indexer-plugins/pull/60) 
+- Add support for multiple notification channels [(#66)](https://github.com/wazuh/wazuh-indexer-reporting/pull/66)
 
 ### Dependencies
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         opensearch_version = System.getProperty("opensearch.version", "3.1.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
-        wazuh_version = System.getProperty("version", "6.0.0")
+        wazuh_version = System.getProperty("version", "5.0.0")
         revision = System.getProperty("revision", "0")
         // 2.0.0-rc1-SNAPSHOT -> 2.0.0.0-rc1-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')


### PR DESCRIPTION
### Description
This PR cleans up the code for the email notifications feature. It also fixes a bug where the notifications where only sent to the first notification channel in the list. Now, the notifications are sent to every notification channel in the list of notification channels added to the reports definition.

### Related Issues
Resolves #65

### Testing

1. Use the development environment in https://github.com/wazuh/wazuh-indexer-reporting/issues/61#issuecomment-3049281837, then build the plugin using this branch and install it into Wazuh Indexer.
2. Start 2 mailpit instances (one in the `server` machine and other in the `mailpit` machine)
3. Configure 2 email notifications channels as described in https://github.com/wazuh/wazuh-indexer-reporting/issues/61#issuecomment-3049281837.
4. Check that email notifications reach both of the SMTP servers.

<img width="1903" height="1054" alt="image" src="https://github.com/user-attachments/assets/91a91e69-187b-457f-81f5-1705ab723eea" />


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/reporting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
