### PR TITLE
Replace third-party Action to check commiter's email with our forked version

### DIFF
--- a/.github/workflows/5_codequality_email-check.yml
+++ b/.github/workflows/5_codequality_email-check.yml
@@ -9,8 +9,8 @@ jobs:
     if: github.repository == 'wazuh/wazuh-indexer-reporting'
     runs-on: ubuntu-24.04
     steps:
-      - uses: semcelik/commit-author-action@v1.0.0
+      - uses: wazuh/wazuh-indexer/.github/actions/5_codeanalysis_emailchecker@main
         with:
-            email_domain: 'wazuh.com'
+            email_domain: 'wazuh.com, @users.noreply.github.com'
             github_token: ${{ secrets.GITHUB_TOKEN }}
             error_on_fail: 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Dependencies
 
 ### Changed
-- Use email checker action from wazuh-indexer in reporting workflow [(#71)](https://github.com/wazuh/wazuh-indexer-reporting/pull/71)
+- Replace third-party Action to check commiter's email with our forked version [(#71)](https://github.com/wazuh/wazuh-indexer-reporting/pull/71)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Dependencies
 
 ### Changed
+- Use email checker action from wazuh-indexer in reporting workflow [(#71)](https://github.com/wazuh/wazuh-indexer-reporting/pull/71)
 
 ### Deprecated
 


### PR DESCRIPTION
### Description
This PR makes the `5_codequality_email-check` workflow use `wazuh/wazuh-indexer/.github/actions/5_codeanalysis_emailchecker@main` to fix the error of it failing during upgrades because some commits are not signed with the `@wazuh.com` mail.

### Related Issues
Resolves #70 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/reporting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
