### PR TITLE
Replace OpensSarch's common-utils to Wazuh's

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -238,7 +238,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
-    implementation "${group}:common-utils:${common_utils_version}"
+    implementation "com.wazuh:wazuh-indexer-common-utils:${common_utils_version}"
     compileOnly "${group}:opensearch-job-scheduler-spi:${job_scheduler_version}"
     implementation "org.json:json:20231013"
     implementation group: 'com.github.wnameless.json', name: 'json-flattener', version: '0.15.1'


### PR DESCRIPTION
### Description
This PR replaces the usage of OpenSearch common-utils dependency with the Wazuh Indexer library

### Related Issues
Closes https://github.com/wazuh/wazuh-indexer-common-utils/issues/1
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
