### PR TITLE
Rework caches in GH Workflows

### DIFF
--- a/.github/workflows/5_testintegration_gradlecheck.yml
+++ b/.github/workflows/5_testintegration_gradlecheck.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ~/.m2/repository
-          key: maven-common-utils-${{ github.ref_name }}
+          key: ${{ github.run_id }}-common-utils
 
   call-test-workflow:
     runs-on: ubuntu-24.04
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.m2/repository
-          key: maven-common-utils-${{ github.ref_name }}
+          key: ${{ github.run_id }}-common-utils
 
       - name: Run Gradle check
         run: ./gradlew check


### PR DESCRIPTION
### Description
Uses .m2 cache to transport artifacts within the same workflow run.

**Validation**
- Run `./gradlew check`

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1443
