### PR TITLE
Limit For Report Definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Implement delivery of notifications on reports creation [(#67)](https://github.com/wazuh/wazuh-indexer-reporting/pull/67)
 - Add `--set-as-main` flag support to repository bumper [(#139)](https://github.com/wazuh/wazuh-indexer-reporting/pull/139)
 - Add revert logic to bumper workflow [(#159)](https://github.com/wazuh/wazuh-indexer-reporting/pull/159)
+- Add limit for report definitions [(#206)](https://github.com/wazuh/wazuh-indexer-reporting/pull/206)
 
 ### Dependencies
 

--- a/src/main/kotlin/org/opensearch/reportsscheduler/ReportsSchedulerPlugin.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/ReportsSchedulerPlugin.kt
@@ -42,6 +42,7 @@ import org.opensearch.reportsscheduler.index.ReportDefinitionsIndex
 import org.opensearch.reportsscheduler.index.ReportDefinitionsIndex.REPORT_DEFINITIONS_INDEX_NAME
 import org.opensearch.reportsscheduler.index.ReportInstancesIndex
 import org.opensearch.reportsscheduler.index.ReportInstancesIndex.REPORT_INSTANCES_INDEX_NAME
+import org.opensearch.reportsscheduler.index.ResourceLockService
 import org.opensearch.reportsscheduler.resthandler.OnDemandReportRestHandler
 import org.opensearch.reportsscheduler.resthandler.ReportDefinitionListRestHandler
 import org.opensearch.reportsscheduler.resthandler.ReportDefinitionRestHandler
@@ -87,7 +88,11 @@ class ReportsSchedulerPlugin : Plugin(), ActionPlugin, SystemIndexPlugin, JobSch
     override fun getSystemIndexDescriptors(settings: Settings): Collection<SystemIndexDescriptor> {
         return listOf(
             SystemIndexDescriptor(REPORT_DEFINITIONS_INDEX_NAME, "Reports Scheduler Plugin Definitions index"),
-            SystemIndexDescriptor(REPORT_INSTANCES_INDEX_NAME, "Reports Scheduler Plugin Instances index")
+            SystemIndexDescriptor(REPORT_INSTANCES_INDEX_NAME, "Reports Scheduler Plugin Instances index"),
+            SystemIndexDescriptor(
+                ResourceLockService.LOCKS_INDEX_NAME,
+                "System index for serializing the report-definition-creation limit check."
+            )
         )
     }
 
@@ -110,6 +115,7 @@ class ReportsSchedulerPlugin : Plugin(), ActionPlugin, SystemIndexPlugin, JobSch
         PluginSettings.addSettingsUpdateConsumer(clusterService)
         ReportDefinitionsIndex.initialize(client, clusterService)
         ReportInstancesIndex.initialize(client, clusterService)
+        ResourceLockService.initialize(client, clusterService)
         val pluginClientInstance = PluginClient(client)
         this.pluginClient = pluginClientInstance
         return listOf(pluginClientInstance)

--- a/src/main/kotlin/org/opensearch/reportsscheduler/action/ReportDefinitionActions.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/action/ReportDefinitionActions.kt
@@ -25,6 +25,7 @@ import org.opensearch.reportsscheduler.model.UpdateReportDefinitionResponse
 import org.opensearch.reportsscheduler.resources.Utils
 import org.opensearch.reportsscheduler.resources.Utils.shouldUseResourceAuthz
 import org.opensearch.reportsscheduler.security.UserAccessManager
+import org.opensearch.reportsscheduler.settings.PluginSettings
 import org.opensearch.reportsscheduler.util.PluginClient
 import org.opensearch.reportsscheduler.util.logger
 import java.time.Instant
@@ -45,6 +46,18 @@ internal object ReportDefinitionActions {
         // only use backend_role path if resource-sharing is disabled
         if (!shouldUseResourceAuthz(Utils.REPORT_DEFINITION_TYPE)) {
             UserAccessManager.validateUser(user)
+        }
+        val count = try {
+            ReportDefinitionsIndex.countReportDefinitions()
+        } catch (e: Exception) {
+            log.warn("$LOG_PREFIX:Failed to count report definitions for limit check: ${e.message}")
+            -1L
+        }
+        if (count >= 0 && count >= PluginSettings.maxReportDefinitions) {
+            throw OpenSearchStatusException(
+                "This request would exceed the maximum allowed report definitions [${PluginSettings.maxReportDefinitions}].",
+                RestStatus.BAD_REQUEST
+            )
         }
         val currentTime = Instant.now()
         val reportDefinitionDetails = ReportDefinitionDetails(

--- a/src/main/kotlin/org/opensearch/reportsscheduler/action/ReportDefinitionActions.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/action/ReportDefinitionActions.kt
@@ -10,6 +10,7 @@ import org.opensearch.commons.authuser.User
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.reportsscheduler.ReportsSchedulerPlugin.Companion.LOG_PREFIX
 import org.opensearch.reportsscheduler.index.ReportDefinitionsIndex
+import org.opensearch.reportsscheduler.index.ResourceLockService
 import org.opensearch.reportsscheduler.metrics.Metrics
 import org.opensearch.reportsscheduler.model.CreateReportDefinitionRequest
 import org.opensearch.reportsscheduler.model.CreateReportDefinitionResponse
@@ -28,6 +29,7 @@ import org.opensearch.reportsscheduler.security.UserAccessManager
 import org.opensearch.reportsscheduler.settings.PluginSettings
 import org.opensearch.reportsscheduler.util.PluginClient
 import org.opensearch.reportsscheduler.util.logger
+import java.io.IOException
 import java.time.Instant
 
 /**
@@ -35,6 +37,8 @@ import java.time.Instant
  */
 internal object ReportDefinitionActions {
     private val log by logger(ReportDefinitionActions::class.java)
+
+    private const val MAX_REPORT_DEFINITIONS_LOCK_ID = "report-definition-creation"
 
     /**
      * Create new ReportDefinition
@@ -47,33 +51,49 @@ internal object ReportDefinitionActions {
         if (!shouldUseResourceAuthz(Utils.REPORT_DEFINITION_TYPE)) {
             UserAccessManager.validateUser(user)
         }
-        val count = try {
-            ReportDefinitionsIndex.countReportDefinitions()
-        } catch (e: Exception) {
-            log.warn("$LOG_PREFIX:Failed to count report definitions for limit check: ${e.message}")
-            -1L
-        }
-        if (count >= 0 && count >= PluginSettings.maxReportDefinitions) {
+
+        // Serialize the limit-check-then-create sequence so concurrent requests cannot all
+        // observe a stale count and overshoot the configured max.
+        val lockId = try {
+            ResourceLockService.acquire(MAX_REPORT_DEFINITIONS_LOCK_ID)
+        } catch (e: IOException) {
+            log.warn("$LOG_PREFIX:${e.message}")
             throw OpenSearchStatusException(
-                "This request would exceed the maximum allowed report definitions [${PluginSettings.maxReportDefinitions}].",
-                RestStatus.BAD_REQUEST
+                "Too many concurrent report definition creation requests, please retry.",
+                RestStatus.TOO_MANY_REQUESTS
             )
         }
-        val currentTime = Instant.now()
-        val reportDefinitionDetails = ReportDefinitionDetails(
-            "ignore",
-            currentTime,
-            currentTime,
-            UserAccessManager.getUserTenant(user),
-            UserAccessManager.getAllAccessInfo(user),
-            request.reportDefinition
-        )
-        val docId = ReportDefinitionsIndex.createReportDefinition(reportDefinitionDetails)
-        docId ?: throw OpenSearchStatusException(
-            "Report Definition Creation failed",
-            RestStatus.INTERNAL_SERVER_ERROR
-        )
-        return CreateReportDefinitionResponse(docId)
+        try {
+            val count = try {
+                ReportDefinitionsIndex.countReportDefinitions()
+            } catch (e: Exception) {
+                log.warn("$LOG_PREFIX:Failed to count report definitions for limit check: ${e.message}")
+                -1L
+            }
+            if (count >= 0 && count >= PluginSettings.maxReportDefinitions) {
+                throw OpenSearchStatusException(
+                    "This request would exceed the maximum allowed report definitions [${PluginSettings.maxReportDefinitions}].",
+                    RestStatus.BAD_REQUEST
+                )
+            }
+            val currentTime = Instant.now()
+            val reportDefinitionDetails = ReportDefinitionDetails(
+                "ignore",
+                currentTime,
+                currentTime,
+                UserAccessManager.getUserTenant(user),
+                UserAccessManager.getAllAccessInfo(user),
+                request.reportDefinition
+            )
+            val docId = ReportDefinitionsIndex.createReportDefinition(reportDefinitionDetails)
+            docId ?: throw OpenSearchStatusException(
+                "Report Definition Creation failed",
+                RestStatus.INTERNAL_SERVER_ERROR
+            )
+            return CreateReportDefinitionResponse(docId)
+        } finally {
+            ResourceLockService.release(lockId)
+        }
     }
 
     /**

--- a/src/main/kotlin/org/opensearch/reportsscheduler/index/ReportDefinitionsIndex.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/index/ReportDefinitionsIndex.kt
@@ -148,6 +148,26 @@ internal object ReportDefinitionsIndex {
     }
 
     /**
+     * Count all report definitions in the index.
+     * Returns 0 if the index does not exist yet (first-boot scenario).
+     * @return total number of report definitions
+     */
+    fun countReportDefinitions(): Long {
+        if (!isIndexExists()) {
+            return 0L
+        }
+        val sourceBuilder = SearchSourceBuilder()
+            .timeout(TimeValue(PluginSettings.operationTimeoutMs, TimeUnit.MILLISECONDS))
+            .size(0)
+            .trackTotalHits(true)
+        val searchRequest = SearchRequest()
+            .indices(REPORT_DEFINITIONS_INDEX_NAME)
+            .source(sourceBuilder)
+        val response = client.search(searchRequest).actionGet(PluginSettings.operationTimeoutMs)
+        return response.hits.totalHits?.value ?: 0L
+    }
+
+    /**
      * Query index for report definition for given access details
      * @param tenant the tenant of the user
      * @param access the list of access details to search reports for.

--- a/src/main/kotlin/org/opensearch/reportsscheduler/index/ReportDefinitionsIndex.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/index/ReportDefinitionsIndex.kt
@@ -12,6 +12,7 @@ import org.opensearch.action.delete.DeleteRequest
 import org.opensearch.action.get.GetRequest
 import org.opensearch.action.index.IndexRequest
 import org.opensearch.action.search.SearchRequest
+import org.opensearch.action.support.WriteRequest
 import org.opensearch.action.update.UpdateRequest
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.unit.TimeValue
@@ -112,6 +113,9 @@ internal object ReportDefinitionsIndex {
         val indexRequest = IndexRequest(REPORT_DEFINITIONS_INDEX_NAME)
             .source(reportDefinitionDetails.toXContent())
             .create(true)
+            // Ensures countReportDefinitions() sees this doc on the very next call, so the
+            // ResourceLockService-guarded limit check isn't fooled by refresh-interval lag.
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
         val actionFuture = client.index(indexRequest)
         val response = actionFuture.actionGet(PluginSettings.operationTimeoutMs)
         return if (response.result != DocWriteResponse.Result.CREATED) {

--- a/src/main/kotlin/org/opensearch/reportsscheduler/index/ResourceLockService.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/index/ResourceLockService.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.reportsscheduler.index
+
+import org.opensearch.ResourceAlreadyExistsException
+import org.opensearch.action.DocWriteRequest
+import org.opensearch.action.admin.indices.create.CreateIndexRequest
+import org.opensearch.action.delete.DeleteRequest
+import org.opensearch.action.get.GetRequest
+import org.opensearch.action.index.IndexRequest
+import org.opensearch.action.support.WriteRequest
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.index.engine.VersionConflictEngineException
+import org.opensearch.reportsscheduler.ReportsSchedulerPlugin.Companion.LOG_PREFIX
+import org.opensearch.reportsscheduler.settings.PluginSettings
+import org.opensearch.reportsscheduler.util.SecureIndexClient
+import org.opensearch.reportsscheduler.util.logger
+import org.opensearch.transport.client.Client
+import java.io.IOException
+import java.time.Instant
+
+/**
+ * Serializes the resource-creation-limit check-then-act sequence (count existing documents, then
+ * create if under the configured max) with a short-lived mutex document per lock ID.
+ *
+ * The mutex is a document with a caller-supplied ID, created via [DocWriteRequest.OpType.CREATE]
+ * so only one caller can hold it at a time for that ID. The resource count itself remains a live
+ * search against the resource index; the lock only prevents two requests from evaluating that
+ * count concurrently with a create.
+ */
+internal object ResourceLockService {
+    private val log by logger(ResourceLockService::class.java)
+
+    const val LOCKS_INDEX_NAME = ".opendistro-reports-resource-locks"
+    private const val MAPPING_FILE_NAME = "resource-locks-mapping.yml"
+    private const val SETTINGS_FILE_NAME = "resource-locks-settings.yml"
+    private const val ACQUIRED_AT_FIELD = "acquired_at"
+    private const val MAX_ACQUIRE_RETRIES = 20
+    private const val ACQUIRE_RETRY_BACKOFF_MILLIS = 100L
+    private const val STALE_THRESHOLD_MILLIS = 30_000L
+
+    private lateinit var client: Client
+    private lateinit var clusterService: ClusterService
+
+    /**
+     * Initialize the class
+     * @param client The ES client
+     * @param clusterService The ES cluster service
+     */
+    fun initialize(client: Client, clusterService: ClusterService) {
+        ResourceLockService.client = SecureIndexClient(client)
+        ResourceLockService.clusterService = clusterService
+    }
+
+    private fun isIndexExists(): Boolean {
+        return clusterService.state().routingTable.hasIndex(LOCKS_INDEX_NAME)
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun createIndex() {
+        if (isIndexExists()) {
+            return
+        }
+        val classLoader = ResourceLockService::class.java.classLoader
+        val indexMappingSource = classLoader.getResource(MAPPING_FILE_NAME)?.readText()!!
+        val indexSettingsSource = classLoader.getResource(SETTINGS_FILE_NAME)?.readText()!!
+        val request = CreateIndexRequest(LOCKS_INDEX_NAME)
+            .mapping(indexMappingSource, XContentType.YAML)
+            .settings(indexSettingsSource, XContentType.YAML)
+        try {
+            client.threadPool().threadContext.stashContext().use {
+                val response = client.admin().indices().create(request).actionGet(PluginSettings.operationTimeoutMs)
+                if (response.isAcknowledged) {
+                    log.info("$LOG_PREFIX:Index $LOCKS_INDEX_NAME creation Acknowledged")
+                } else {
+                    error("$LOG_PREFIX:Index $LOCKS_INDEX_NAME creation not Acknowledged")
+                }
+            }
+        } catch (exception: ResourceAlreadyExistsException) {
+            log.warn("message: ${exception.message}")
+        } catch (exception: Exception) {
+            if (exception.cause !is ResourceAlreadyExistsException) {
+                throw exception
+            }
+        }
+    }
+
+    /**
+     * Acquires the mutex for the given lock ID, blocking (with bounded retries) until it becomes
+     * available.
+     *
+     * @param lockId the lock document ID.
+     * @return the lock document ID, to be passed to [release].
+     * @throws IOException if the lock could not be acquired after [MAX_ACQUIRE_RETRIES] attempts.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    fun acquire(lockId: String): String {
+        createIndex()
+        for (attempt in 1..MAX_ACQUIRE_RETRIES) {
+            try {
+                val request = IndexRequest(LOCKS_INDEX_NAME)
+                    .id(lockId)
+                    .source(mapOf(ACQUIRED_AT_FIELD to Instant.now().toEpochMilli()))
+                    .opType(DocWriteRequest.OpType.CREATE)
+                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                client.index(request).actionGet(PluginSettings.operationTimeoutMs)
+                return lockId
+            } catch (e: VersionConflictEngineException) {
+                if (stealIfStale(lockId)) {
+                    continue
+                }
+                backoff()
+            }
+        }
+        throw IOException("Timed out waiting for the resource-creation lock on [$lockId].")
+    }
+
+    /**
+     * Releases a previously acquired lock. Failures are logged and swallowed so a release problem
+     * never surfaces as a resource-creation failure; a lock older than [STALE_THRESHOLD_MILLIS] is
+     * stolen by the next caller regardless.
+     *
+     * @param lockId the lock document ID returned by [acquire].
+     */
+    fun release(lockId: String) {
+        try {
+            val request = DeleteRequest(LOCKS_INDEX_NAME, lockId)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            client.delete(request).actionGet(PluginSettings.operationTimeoutMs)
+        } catch (e: Exception) {
+            log.warn("Failed to release resource-creation lock [$lockId]: ${e.message}")
+        }
+    }
+
+    /**
+     * Deletes the lock document if it was acquired more than [STALE_THRESHOLD_MILLIS] ago,
+     * guarding against a lock orphaned by a crashed node.
+     *
+     * @param lockId the lock document ID.
+     * @return true if the stale lock was stolen (deleted) and the caller should retry immediately.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun stealIfStale(lockId: String): Boolean {
+        return try {
+            val response = client.get(GetRequest(LOCKS_INDEX_NAME, lockId)).actionGet(PluginSettings.operationTimeoutMs)
+            if (!response.isExists) {
+                // Released concurrently between our failed acquire and this check; retry immediately.
+                return true
+            }
+            val acquiredAt = response.sourceAsMap?.get(ACQUIRED_AT_FIELD)
+            val acquiredAtMillis = if (acquiredAt is Number) acquiredAt.toLong() else 0L
+            if (Instant.now().toEpochMilli() - acquiredAtMillis <= STALE_THRESHOLD_MILLIS) {
+                return false
+            }
+            log.warn("Stealing stale resource-creation lock [$lockId].")
+            val deleteRequest = DeleteRequest(LOCKS_INDEX_NAME, lockId)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            client.delete(deleteRequest).actionGet(PluginSettings.operationTimeoutMs)
+            true
+        } catch (e: Exception) {
+            log.warn("Failed to check staleness of resource-creation lock [$lockId]: ${e.message}")
+            false
+        }
+    }
+
+    private fun backoff() {
+        Thread.sleep(ACQUIRE_RETRY_BACKOFF_MILLIS)
+    }
+}

--- a/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
@@ -58,7 +58,7 @@ internal object PluginSettings {
      * Maximum number of report definitions allowed. Requests exceeding this limit are rejected
      * with a 400 error.
      */
-    private const val MAX_REPORT_DEFINITIONS_KEY = "plugins.reports.general.max_report_definitions"
+    private const val MAX_REPORT_DEFINITIONS_KEY = "plugins.reports.max_report_definitions"
 
     /**
      * Default operation timeout for network operations.

--- a/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
@@ -55,6 +55,12 @@ internal object PluginSettings {
     private const val FILTER_BY_BACKEND_ROLES_KEY = "plugins.alerting.filter_by_backend_roles"
 
     /**
+     * Maximum number of report definitions allowed. Requests exceeding this limit are rejected
+     * with a 400 error.
+     */
+    private const val MAX_REPORT_DEFINITIONS_KEY = "$GENERAL_KEY_PREFIX.maxReportDefinitions"
+
+    /**
      * Default operation timeout for network operations.
      */
     private const val DEFAULT_OPERATION_TIMEOUT_MS = 60000L
@@ -74,6 +80,16 @@ internal object PluginSettings {
      */
     private const val MINIMUM_ITEMS_QUERY_COUNT = 10
 
+    /**
+     * Default maximum number of report definitions.
+     */
+    private const val DEFAULT_MAX_REPORT_DEFINITIONS_VALUE = 100
+
+    /**
+     * Minimum allowed value for the max report definitions setting.
+     */
+    private const val MINIMUM_MAX_REPORT_DEFINITIONS = 0
+
     private const val DECIMAL_RADIX: Int = 10
 
     /**
@@ -87,6 +103,12 @@ internal object PluginSettings {
      */
     @Volatile
     var defaultItemsQueryCount: Int
+
+    /**
+     * Maximum number of report definitions allowed.
+     */
+    @Volatile
+    var maxReportDefinitions: Int
 
     private val log = LogManager.getLogger(javaClass)
     private val defaultSettings: Map<String, String>
@@ -106,10 +128,13 @@ internal object PluginSettings {
         operationTimeoutMs = (settings?.get(OPERATION_TIMEOUT_MS_KEY)?.toLong()) ?: DEFAULT_OPERATION_TIMEOUT_MS
         defaultItemsQueryCount = (settings?.get(DEFAULT_ITEMS_QUERY_COUNT_KEY)?.toInt())
             ?: DEFAULT_ITEMS_QUERY_COUNT_VALUE
+        maxReportDefinitions = (settings?.get(MAX_REPORT_DEFINITIONS_KEY)?.toInt())
+            ?: DEFAULT_MAX_REPORT_DEFINITIONS_VALUE
 
         defaultSettings = mapOf(
             OPERATION_TIMEOUT_MS_KEY to operationTimeoutMs.toString(DECIMAL_RADIX),
-            DEFAULT_ITEMS_QUERY_COUNT_KEY to defaultItemsQueryCount.toString(DECIMAL_RADIX)
+            DEFAULT_ITEMS_QUERY_COUNT_KEY to defaultItemsQueryCount.toString(DECIMAL_RADIX),
+            MAX_REPORT_DEFINITIONS_KEY to maxReportDefinitions.toString(DECIMAL_RADIX)
         )
     }
 
@@ -125,6 +150,14 @@ internal object PluginSettings {
         DEFAULT_ITEMS_QUERY_COUNT_KEY,
         defaultSettings[DEFAULT_ITEMS_QUERY_COUNT_KEY]!!.toInt(),
         MINIMUM_ITEMS_QUERY_COUNT,
+        NodeScope,
+        Dynamic
+    )
+
+    private val MAX_REPORT_DEFINITIONS: Setting<Int> = Setting.intSetting(
+        MAX_REPORT_DEFINITIONS_KEY,
+        defaultSettings[MAX_REPORT_DEFINITIONS_KEY]!!.toInt(),
+        MINIMUM_MAX_REPORT_DEFINITIONS,
         NodeScope,
         Dynamic
     )
@@ -163,7 +196,8 @@ internal object PluginSettings {
     fun getAllSettings(): List<Setting<*>> {
         return listOf(
             OPERATION_TIMEOUT_MS,
-            DEFAULT_ITEMS_QUERY_COUNT
+            DEFAULT_ITEMS_QUERY_COUNT,
+            MAX_REPORT_DEFINITIONS
         )
     }
 
@@ -174,6 +208,7 @@ internal object PluginSettings {
     private fun updateSettingValuesFromLocal(clusterService: ClusterService) {
         operationTimeoutMs = OPERATION_TIMEOUT_MS.get(clusterService.settings)
         defaultItemsQueryCount = DEFAULT_ITEMS_QUERY_COUNT.get(clusterService.settings)
+        maxReportDefinitions = MAX_REPORT_DEFINITIONS.get(clusterService.settings)
     }
 
     /**
@@ -190,6 +225,11 @@ internal object PluginSettings {
         if (clusterDefaultItemsQueryCount != null) {
             log.debug("$LOG_PREFIX:$DEFAULT_ITEMS_QUERY_COUNT_KEY -autoUpdatedTo-> $clusterDefaultItemsQueryCount")
             defaultItemsQueryCount = clusterDefaultItemsQueryCount
+        }
+        val clusterMaxReportDefinitions = clusterService.clusterSettings.get(MAX_REPORT_DEFINITIONS)
+        if (clusterMaxReportDefinitions != null) {
+            log.debug("$LOG_PREFIX:$MAX_REPORT_DEFINITIONS_KEY -autoUpdatedTo-> $clusterMaxReportDefinitions")
+            maxReportDefinitions = clusterMaxReportDefinitions
         }
     }
 
@@ -211,6 +251,10 @@ internal object PluginSettings {
         clusterService.clusterSettings.addSettingsUpdateConsumer(DEFAULT_ITEMS_QUERY_COUNT) {
             defaultItemsQueryCount = it
             log.info("$LOG_PREFIX:$DEFAULT_ITEMS_QUERY_COUNT_KEY -updatedTo-> $it")
+        }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(MAX_REPORT_DEFINITIONS) {
+            maxReportDefinitions = it
+            log.info("$LOG_PREFIX:$MAX_REPORT_DEFINITIONS_KEY -updatedTo-> $it")
         }
     }
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
@@ -58,7 +58,7 @@ internal object PluginSettings {
      * Maximum number of report definitions allowed. Requests exceeding this limit are rejected
      * with a 400 error.
      */
-    private const val MAX_REPORT_DEFINITIONS_KEY = "$GENERAL_KEY_PREFIX.maxReportDefinitions"
+    private const val MAX_REPORT_DEFINITIONS_KEY = "plugins.reports.general.max_report_definitions"
 
     /**
      * Default operation timeout for network operations.
@@ -83,7 +83,7 @@ internal object PluginSettings {
     /**
      * Default maximum number of report definitions.
      */
-    private const val DEFAULT_MAX_REPORT_DEFINITIONS_VALUE = 100
+    private const val DEFAULT_MAX_REPORT_DEFINITIONS_VALUE = 50
 
     /**
      * Minimum allowed value for the max report definitions setting.

--- a/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
@@ -81,9 +81,15 @@ internal object PluginSettings {
     private const val MINIMUM_ITEMS_QUERY_COUNT = 10
 
     /**
-     * Default maximum number of report definitions.
+     * Maximum allowed value for the max report definitions setting.
      */
-    private const val DEFAULT_MAX_REPORT_DEFINITIONS_VALUE = 50
+    private const val MAXIMUM_MAX_REPORT_DEFINITIONS = 50
+
+    /**
+     * Default maximum number of report definitions. Equals the maximum to prevent
+     * accidental over-provisioning by default.
+     */
+    private const val DEFAULT_MAX_REPORT_DEFINITIONS_VALUE = MAXIMUM_MAX_REPORT_DEFINITIONS
 
     /**
      * Minimum allowed value for the max report definitions setting.
@@ -158,6 +164,7 @@ internal object PluginSettings {
         MAX_REPORT_DEFINITIONS_KEY,
         defaultSettings[MAX_REPORT_DEFINITIONS_KEY]!!.toInt(),
         MINIMUM_MAX_REPORT_DEFINITIONS,
+        MAXIMUM_MAX_REPORT_DEFINITIONS,
         NodeScope,
         Dynamic
     )

--- a/src/main/resources/resource-locks-mapping.yml
+++ b/src/main/resources/resource-locks-mapping.yml
@@ -1,0 +1,12 @@
+---
+##
+ # Copyright OpenSearch Contributors
+ # SPDX-License-Identifier: Apache-2.0
+##
+
+# Schema file for the resource-locks index
+# "dynamic" is set to "strict" so this index only ever holds the fields the lock service uses.
+dynamic: strict
+properties:
+  acquired_at:
+    type: long

--- a/src/main/resources/resource-locks-settings.yml
+++ b/src/main/resources/resource-locks-settings.yml
@@ -1,0 +1,12 @@
+---
+##
+ # Copyright OpenSearch Contributors
+ # SPDX-License-Identifier: Apache-2.0
+##
+
+# Settings file for the resource-locks index
+index:
+  number_of_shards: "1"
+  number_of_replicas: "0"
+  hidden: true
+  refresh_interval: "-1" # Lock acquire/release explicitly request an immediate refresh per write.


### PR DESCRIPTION
### Description
This PR implements limits for the number of Reports that can be defined.

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/1276

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/reporting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
