### PR TITLE
Sync CHANGELOG "Prior versions" against real release branches

### DIFF
--- a/tools/changelog_prior_versions_sync.sh
+++ b/tools/changelog_prior_versions_sync.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+# =========================
+# Changelog Prior Versions Sync
+# =========================
+# Walks backwards from the given version looking for release branches that
+# exist on the remote but are missing from CHANGELOG.md's "## Prior versions"
+# section, and adds them. Called by repository_bumper.sh after every bump.
+#
+# Within the current (still open) minor, every earlier existing patch is
+# included. For each earlier, already-closed minor, only its ".0" baseline
+# plus the two highest existing patches above it are included.
+#
+# Arguments:
+# 1. The version just bumped to (e.g., 5.1.1)
+
+set -euo pipefail
+
+function log() {
+    echo "[$(date +"%Y-%m-%d %H:%M:%S")] $1"
+}
+
+# ====
+# Determine the "org/repo" path from the origin remote URL.
+# ====
+function get_repo_path() {
+    local remote_url
+    remote_url=$(git remote get-url origin)
+    remote_url="${remote_url%.git}"
+    remote_url="${remote_url#*github.com/}"
+    remote_url="${remote_url#*github.com:}"
+    echo "$remote_url"
+}
+
+# ====
+# Check whether a branch named "X.Y.Z" or "vX.Y.Z" exists on the remote.
+# Arguments:
+#   $1 - version (e.g. 5.0.1)
+# ====
+function remote_branch_exists() {
+    local version="$1"
+    git ls-remote --exit-code --heads origin "$version" &>/dev/null ||
+        git ls-remote --exit-code --heads origin "v$version" &>/dev/null
+}
+
+# ====
+# Add a version entry to CHANGELOG.md's "## Prior versions" section, if not
+# already present. Each call inserts right below the heading, so callers
+# must call this oldest-version-first for the final list to read newest-first.
+# Arguments:
+#   $1 - version to record
+# ====
+function add_prior_version_entry() {
+    local version="$1"
+    local file="CHANGELOG.md"
+    local repo_path
+    repo_path=$(get_repo_path)
+    local entry="- [${version}](https://github.com/${repo_path}/blob/${version}/CHANGELOG.md)"
+
+    if [[ ! -f "$file" ]]; then
+        log "Warning: $file not found; skipping Prior versions update."
+        return 0
+    fi
+
+    if grep -qF -- "$entry" "$file"; then
+        return 0
+    fi
+
+    if grep -qE "^## Prior versions?$" "$file"; then
+        # Matches singular or plural heading; replaces the "- []()" placeholder if present.
+        awk -v entry="$entry" '
+            /^## Prior versions?$/ && !done {
+                print "## Prior versions"
+                print entry
+                done = 1
+                skip_placeholder = 1
+                next
+            }
+            skip_placeholder {
+                skip_placeholder = 0
+                if ($0 == "- []()") next
+            }
+            { print }
+        ' "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
+    else
+        {
+            echo ""
+            echo "## Prior versions"
+            echo "$entry"
+        } >> "$file"
+    fi
+
+    log "Added $version to Prior versions in $file"
+}
+
+# ====
+# Every existing patch below the given one, within the same (still open)
+# minor. Emitted oldest first.
+# Arguments:
+#   $1 - major, $2 - minor, $3 - patch (exclusive upper bound)
+# ====
+function current_minor_candidates() {
+    local major="$1" minor="$2" patch="$3"
+    local p candidate
+    for ((p = 0; p < patch; p++)); do
+        candidate="${major}.${minor}.${p}"
+        if remote_branch_exists "$candidate"; then
+            echo "$candidate"
+        fi
+    done
+}
+
+# ====
+# For an already-closed minor: its ".0" baseline (if it exists), plus the two
+# highest existing patches above it. Emitted oldest first (baseline, then the
+# kept patches in ascending order).
+# Arguments:
+#   $1 - major, $2 - minor
+# ====
+function closed_minor_candidates() {
+    local major="$1" minor="$2"
+    local baseline="${major}.${minor}.0"
+
+    local p candidate
+    local -a found=()
+    for ((p = 1; p <= 9; p++)); do
+        candidate="${major}.${minor}.${p}"
+        if remote_branch_exists "$candidate"; then
+            found+=("$candidate")
+        fi
+    done
+
+    if remote_branch_exists "$baseline"; then
+        echo "$baseline"
+    fi
+
+    local count=${#found[@]}
+    local start=0
+    if ((count > 2)); then
+        start=$((count - 2))
+    fi
+
+    local i
+    for ((i = start; i < count; i++)); do
+        echo "${found[$i]}"
+    done
+}
+
+# ====
+# Build the full list of candidate versions to add, oldest first (see
+# add_prior_version_entry for why the order matters).
+# Arguments:
+#   $1 - version (e.g. 5.1.1)
+# ====
+function build_candidates() {
+    local version="$1"
+    local major minor patch
+    IFS='.' read -r major minor patch <<< "$version"
+
+    local y
+    for ((y = 0; y <= minor - 1; y++)); do
+        closed_minor_candidates "$major" "$y"
+    done
+
+    current_minor_candidates "$major" "$minor" "$patch"
+}
+
+# ====
+# Main logic
+# ====
+function main() {
+    if [[ $# -ne 1 ]]; then
+        log "Usage: $0 <version>"
+        exit 1
+    fi
+
+    local version="$1"
+
+    while IFS= read -r candidate; do
+        add_prior_version_entry "$candidate"
+    done < <(build_candidates "$version")
+}
+
+main "$@"

--- a/tools/changelog_prior_versions_sync.sh
+++ b/tools/changelog_prior_versions_sync.sh
@@ -3,13 +3,14 @@
 # =========================
 # Changelog Prior Versions Sync
 # =========================
-# Walks backwards from the given version looking for release branches that
-# exist on the remote but are missing from CHANGELOG.md's "## Prior versions"
-# section, and adds them. Called by repository_bumper.sh after every bump.
+# Fetches every branch on the remote once, then adds to CHANGELOG.md's
+# "## Prior versions" section any version (within the same major as the one
+# just bumped to) that is missing from it. Called by repository_bumper.sh
+# after every bump.
 #
-# Within the current (still open) minor, every earlier existing patch is
-# included. For each earlier, already-closed minor, only its ".0" baseline
-# plus the two highest existing patches above it are included.
+# For every minor found (the one just bumped into included), only its ".0"
+# baseline (if it exists) plus the two highest existing patches above it are
+# added.
 #
 # Arguments:
 # 1. The version just bumped to (e.g., 5.1.1)
@@ -21,7 +22,7 @@ function log() {
 }
 
 # ====
-# Determine the "org/repo" path from the origin remote URL.
+# Determine the repo path from the origin remote URL.
 # ====
 function get_repo_path() {
     local remote_url
@@ -30,17 +31,6 @@ function get_repo_path() {
     remote_url="${remote_url#*github.com/}"
     remote_url="${remote_url#*github.com:}"
     echo "$remote_url"
-}
-
-# ====
-# Check whether a branch named "X.Y.Z" or "vX.Y.Z" exists on the remote.
-# Arguments:
-#   $1 - version (e.g. 5.0.1)
-# ====
-function remote_branch_exists() {
-    local version="$1"
-    git ls-remote --exit-code --heads origin "$version" &>/dev/null ||
-        git ls-remote --exit-code --heads origin "v$version" &>/dev/null
 }
 
 # ====
@@ -94,56 +84,65 @@ function add_prior_version_entry() {
 }
 
 # ====
-# Every existing patch below the given one, within the same (still open)
-# minor. Emitted oldest first.
+# Fetch every branch on the remote once, keep only version-shaped names
+# ("X.Y.Z" or "vX.Y.Z") belonging to the given major, excluding the version
+# just bumped to. Emits "minor<TAB>patch<TAB>name" lines, any order.
 # Arguments:
-#   $1 - major, $2 - minor, $3 - patch (exclusive upper bound)
+#   $1 - major
+#   $2 - version just bumped to, to exclude (e.g. 5.1.1)
 # ====
-function current_minor_candidates() {
-    local major="$1" minor="$2" patch="$3"
-    local p candidate
-    for ((p = 0; p < patch; p++)); do
-        candidate="${major}.${minor}.${p}"
-        if remote_branch_exists "$candidate"; then
-            echo "$candidate"
-        fi
-    done
+function fetch_major_branches() {
+    local major="$1"
+    local exclude="$2"
+
+    local all_branches
+    all_branches=$(git ls-remote --heads origin | sed -E 's#^[0-9a-f]+[[:space:]]+refs/heads/##')
+
+    local versioned
+    versioned=$(printf '%s\n' "$all_branches" | grep -E "^v?[0-9]+\.[0-9]+\.[0-9]+$" || true)
+
+    [[ -z "$versioned" ]] && return 0
+
+    local name stripped b_major rest b_minor b_patch
+    while IFS= read -r name; do
+        stripped="${name#v}"
+        b_major="${stripped%%.*}"
+        [[ "$b_major" != "$major" ]] && continue
+        [[ "$stripped" == "$exclude" ]] && continue
+        rest="${stripped#*.}"
+        b_minor="${rest%%.*}"
+        b_patch="${rest#*.}"
+        printf '%s\t%s\t%s\n' "$b_minor" "$b_patch" "$name"
+    done <<< "$versioned"
 }
 
 # ====
-# For an already-closed minor: its ".0" baseline (if it exists), plus the two
-# highest existing patches above it. Emitted oldest first (baseline, then the
-# kept patches in ascending order).
-# Arguments:
-#   $1 - major, $2 - minor
+# Given "minor<TAB>patch<TAB>name" lines for a SINGLE minor on stdin, emit
+# its ".0" baseline (if present) plus its two highest non-baseline patches.
+# Emitted oldest first.
 # ====
-function closed_minor_candidates() {
-    local major="$1" minor="$2"
-    local baseline="${major}.${minor}.0"
+function minor_entries() {
+    local baseline=""
+    local -a others=()
+    local _ patch name
 
-    local p candidate
-    local -a found=()
-    for ((p = 1; p <= 9; p++)); do
-        candidate="${major}.${minor}.${p}"
-        if remote_branch_exists "$candidate"; then
-            found+=("$candidate")
+    while IFS=$'\t' read -r _ patch name; do
+        if [[ "$patch" == "0" ]]; then
+            baseline="$name"
+        else
+            others+=("$patch $name")
         fi
     done
 
-    if remote_branch_exists "$baseline"; then
+    if [[ -n "$baseline" ]]; then
         echo "$baseline"
     fi
 
-    local count=${#found[@]}
-    local start=0
-    if ((count > 2)); then
-        start=$((count - 2))
+    if ((${#others[@]} > 0)); then
+        printf '%s\n' "${others[@]}" | sort -rn | head -2 | sort -n | while IFS=' ' read -r _ name; do
+            echo "$name"
+        done
     fi
-
-    local i
-    for ((i = start; i < count; i++)); do
-        echo "${found[$i]}"
-    done
 }
 
 # ====
@@ -154,15 +153,17 @@ function closed_minor_candidates() {
 # ====
 function build_candidates() {
     local version="$1"
-    local major minor patch
-    IFS='.' read -r major minor patch <<< "$version"
+    local major="${version%%.*}"
 
-    local y
-    for ((y = 0; y <= minor - 1; y++)); do
-        closed_minor_candidates "$major" "$y"
+    local branches
+    branches=$(fetch_major_branches "$major" "$version")
+
+    [[ -z "$branches" ]] && return 0
+
+    local minor
+    for minor in $(printf '%s\n' "$branches" | cut -f1 | sort -un); do
+        printf '%s\n' "$branches" | awk -F'\t' -v m="$minor" '$1 == m' | minor_entries
     done
-
-    current_minor_candidates "$major" "$minor" "$patch"
 }
 
 # ====

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -17,10 +17,10 @@ set -euo pipefail
 # Print usage instructions
 # ====
 function usage() {
-    echo "Usage: $0 <version> <stage>"
+    echo "Usage: $0 <version> <stage> [--set-as-main]"
     echo "  version:  The new version to set in VERSION.json (e.g., 4.5.0)"
     echo "  stage:    The new stage to set in VERSION.json (alpha, beta, rc, stable)"
-    echo "  --set-as-main: (Optional) Enable main branch mode: bump version values only,"
+    echo "  --set-as-main: (Optional) Enable main branch mode: bump version values only, keep branch references pointing to main"
     exit 1
 }
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -3,9 +3,10 @@
 # =========================
 # Repository Bumper Script
 # =========================
-# This script updates the VERSION.json file for a new version release.
+# Updates VERSION.json for a new release, and, when --set-as-main is used,
+# records the outgoing version under CHANGELOG.md's "## Prior versions".
 #
-# It takes three arguments:
+# Arguments:
 # 1. The new version to set (e.g., 4.5.0)
 # 2. The new stage to set (alpha, beta, rc, stable)
 # 3. --set-as-main (optional): bump version values only, keep branch references pointing to main
@@ -127,6 +128,70 @@ function update_version_file() {
     log "Updated $file with version=$version and stage=$stage"
 }
 
+# ====
+# Determine the "org/repo" slug from the origin remote URL.
+# ====
+function get_repo_slug() {
+    local remote_url
+    remote_url=$(git remote get-url origin)
+    remote_url="${remote_url%.git}"
+    remote_url="${remote_url#*github.com/}"
+    remote_url="${remote_url#*github.com:}"
+    echo "$remote_url"
+}
+
+# ====
+# Add the outgoing version to CHANGELOG.md's "## Prior versions" section.
+# Only called when main moves to a new version (--set-as-main).
+# Arguments:
+#   $1 - previous version
+# ====
+function update_changelog_prior_versions() {
+    local prev_version="$1"
+    local file="CHANGELOG.md"
+    local repo_slug
+    repo_slug=$(get_repo_slug)
+    local entry="- [${prev_version}](https://github.com/${repo_slug}/blob/${prev_version}/CHANGELOG.md)"
+
+    if [[ ! -f "$file" ]]; then
+        log "Warning: $file not found; skipping Prior versions update."
+        return 0
+    fi
+
+    if grep -qF -- "$entry" "$file"; then
+        log "Prior versions already contains an entry for $prev_version; skipping."
+        return 0
+    fi
+
+    if grep -qE "^## Prior versions?$" "$file"; then
+        # Also matches the legacy singular "## Prior version" heading left
+        # behind by the manual fix on 5.0.0, normalizing it to plural, and
+        # replaces a dangling "- []()" placeholder instead of leaving it
+        # alongside the real entry.
+        awk -v entry="$entry" '
+            /^## Prior versions?$/ && !done {
+                print "## Prior versions"
+                print entry
+                done = 1
+                skip_placeholder = 1
+                next
+            }
+            skip_placeholder {
+                skip_placeholder = 0
+                if ($0 == "- []()") next
+            }
+            { print }
+        ' "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
+    else
+        {
+            echo ""
+            echo "## Prior versions"
+            echo "$entry"
+        } >> "$file"
+    fi
+
+    log "Added $prev_version to Prior versions in $file"
+}
 
 # ====
 # Main logic
@@ -164,7 +229,12 @@ function main() {
     navigate_to_project_root
     check_jq_installed
     validate_inputs "$version" "$stage"
+    local old_version
+    old_version=$(jq -r '.version' VERSION.json)
     update_version_file "$version" "$stage"
+    if [[ "$set_as_main" == "yes" ]] && [[ "$old_version" != "$version" ]]; then
+        update_changelog_prior_versions "$old_version"
+    fi
     log "Update complete."
 }
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -3,14 +3,13 @@
 # =========================
 # Repository Bumper Script
 # =========================
-# Updates VERSION.json for a new release, and, when --set-as-main is used,
-# records the outgoing version under CHANGELOG.md's "## Prior versions".
+# Updates VERSION.json for a new release, then syncs any missing entries
+# in CHANGELOG.md's "## Prior versions" (see changelog_prior_versions_sync.sh).
 #
-# Arguments:
+# It takes three arguments:
 # 1. The new version to set (e.g., 4.5.0)
 # 2. The new stage to set (alpha, beta, rc, stable)
-# 3. --set-as-main (optional): bump version values only, keep branch references pointing to main
-#
+# 3. --set-as-main (optional): enables main branch mode.
 
 set -euo pipefail
 
@@ -18,10 +17,10 @@ set -euo pipefail
 # Print usage instructions
 # ====
 function usage() {
-    echo "Usage: $0 <version> <stage> [--set-as-main]"
-    echo "  version:       The new version to set in VERSION.json (e.g., 4.5.0)"
-    echo "  stage:         The new stage to set in VERSION.json (alpha, beta, rc, stable)"
-    echo "  --set-as-main  Enable main branch mode: bump version values only, keep branch references pointing to main"
+    echo "Usage: $0 <version> <stage>"
+    echo "  version:  The new version to set in VERSION.json (e.g., 4.5.0)"
+    echo "  stage:    The new stage to set in VERSION.json (alpha, beta, rc, stable)"
+    echo "  --set-as-main: (Optional) Enable main branch mode: bump version values only,"
     exit 1
 }
 
@@ -129,71 +128,6 @@ function update_version_file() {
 }
 
 # ====
-# Determine the "org/repo" slug from the origin remote URL.
-# ====
-function get_repo_slug() {
-    local remote_url
-    remote_url=$(git remote get-url origin)
-    remote_url="${remote_url%.git}"
-    remote_url="${remote_url#*github.com/}"
-    remote_url="${remote_url#*github.com:}"
-    echo "$remote_url"
-}
-
-# ====
-# Add the outgoing version to CHANGELOG.md's "## Prior versions" section.
-# Only called when main moves to a new version (--set-as-main).
-# Arguments:
-#   $1 - previous version
-# ====
-function update_changelog_prior_versions() {
-    local prev_version="$1"
-    local file="CHANGELOG.md"
-    local repo_slug
-    repo_slug=$(get_repo_slug)
-    local entry="- [${prev_version}](https://github.com/${repo_slug}/blob/${prev_version}/CHANGELOG.md)"
-
-    if [[ ! -f "$file" ]]; then
-        log "Warning: $file not found; skipping Prior versions update."
-        return 0
-    fi
-
-    if grep -qF -- "$entry" "$file"; then
-        log "Prior versions already contains an entry for $prev_version; skipping."
-        return 0
-    fi
-
-    if grep -qE "^## Prior versions?$" "$file"; then
-        # Also matches the legacy singular "## Prior version" heading left
-        # behind by the manual fix on 5.0.0, normalizing it to plural, and
-        # replaces a dangling "- []()" placeholder instead of leaving it
-        # alongside the real entry.
-        awk -v entry="$entry" '
-            /^## Prior versions?$/ && !done {
-                print "## Prior versions"
-                print entry
-                done = 1
-                skip_placeholder = 1
-                next
-            }
-            skip_placeholder {
-                skip_placeholder = 0
-                if ($0 == "- []()") next
-            }
-            { print }
-        ' "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
-    else
-        {
-            echo ""
-            echo "## Prior versions"
-            echo "$entry"
-        } >> "$file"
-    fi
-
-    log "Added $prev_version to Prior versions in $file"
-}
-
-# ====
 # Main logic
 # ====
 function main() {
@@ -229,12 +163,9 @@ function main() {
     navigate_to_project_root
     check_jq_installed
     validate_inputs "$version" "$stage"
-    local old_version
-    old_version=$(jq -r '.version' VERSION.json)
     update_version_file "$version" "$stage"
-    if [[ "$set_as_main" == "yes" ]] && [[ "$old_version" != "$version" ]]; then
-        update_changelog_prior_versions "$old_version"
-    fi
+    bash "$(dirname "${BASH_SOURCE[0]}")/changelog_prior_versions_sync.sh" "$version"
+
     log "Update complete."
 }
 


### PR DESCRIPTION
### Description
Adds automatic maintenance of CHANGELOG.md's "## Prior versions" section to the repository bumper script: after every bump, it checks the remote for release branches that actually exist and adds the ones still missing  (keeping, per minor line, only its base release plus the two most recent patches).

### Issues Resolved
Resolves IDR5387
