### PR TITLE
Adopt new PR template and no-changelog label

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,75 @@
-<!--  Thanks for sending a pull request, here are some tips:
+## Description
 
-1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
-2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
-3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
+<!--
+Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.
+
+If this pull request resolves an existing issue, reference it here. For example:
+Closes #<issue_number>
 -->
 
-### Description
-[Describe what this change achieves]
+## Proposed Changes
 
-### Related Issues
-Resolves #[Issue number to be closed when this PR is merged]
-<!-- List any other related issues here -->
+<!--
+Summarize the changes made in this pull request. Include:
+- Features added
+- Bugs fixed
+- Any relevant technical details
+-->
 
-### Check List
-- [ ] Functionality includes testing.
-- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
-- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
+### Results and Evidence
 
-By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
-For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
+<!--
+Provide evidence of the changes made, such as:
+- Logs
+- Screenshots
+- Before/after comparisons
+-->
+
+### Artifacts Affected
+
+<!--
+List the artifacts impacted by this pull request, such as:
+- Executables (specify platforms if applicable)
+- Default configuration files
+- Packages
+-->
+
+### Configuration Changes
+
+<!--
+If applicable, list any configuration changes introduced by this pull request, including:
+- New configuration parameters
+- Changes to default values
+- Backward compatibility notes
+-->
+
+### Documentation Updates
+
+<!--
+If applicable, list the sections of documentation that have been updated as part of this pull request.
+-->
+
+### Tests Introduced
+
+<!--
+If applicable, describe any new unit or integration tests added as part of this pull request. Include:
+- Scope of the tests
+- Any relevant details about test coverage
+-->
+
+## Review Checklist
+
+<!--
+List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
+-->
+
+- [ ] Code changes reviewed
+- [ ] Relevant evidence provided
+- [ ] Tests cover the new functionality
+- [ ] Configuration changes documented
+- [ ] Developer documentation reflects the changes
+- [ ] Meets requirements and/or definition of done
+- [ ] No unresolved dependencies with other issues
+- [ ] PR is linked to the relevant issue(s)
+- [ ] Correct labels applied (e.g., `no-changelog`)
+- [ ] ...

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,10 @@
+<!--  Thanks for sending a pull request, here are some tips:
+
+1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
+2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
+3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
+-->
+
 ### Description
 [Describe what this change achieves]
 
@@ -6,11 +13,9 @@ Resolves #[Issue number to be closed when this PR is merged]
 <!-- List any other related issues here -->
 
 ### Check List
-- [ ] New functionality includes testing.
-- [ ] New functionality has been documented.
-- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
-- [ ] Commits are signed per the DCO using `--signoff`.
-- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).
+- [ ] Functionality includes testing.
+- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
+- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
-For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/reporting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
+For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

--- a/.github/workflows/5_codequality_changelog.yml
+++ b/.github/workflows/5_codequality_changelog.yml
@@ -17,5 +17,5 @@ jobs:
       - uses: dangoslen/changelog-enforcer@v3
         id: verify-changelog
         with:
-          skipLabels: "autocut, skip-changelog"
+          skipLabels: "no-changelog"
           changeLogPath: "CHANGELOG.md"


### PR DESCRIPTION
### Description
Updates the pull request template to the org-wide standard and switches the changelog enforcer workflow to accept only the new `no-changelog` skip label, retiring `autocut`/`skip-changelog`. 

### Issues Resolved
https://github.com/wazuh/internal-devel-requests/issues/5504

