### PR TITLE
Remove reporting setting maximum values

### DIFF
--- a/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
@@ -81,15 +81,9 @@ internal object PluginSettings {
     private const val MINIMUM_ITEMS_QUERY_COUNT = 10
 
     /**
-     * Maximum allowed value for the max report definitions setting.
+     * Default maximum number of report definitions.
      */
-    private const val MAXIMUM_MAX_REPORT_DEFINITIONS = 50
-
-    /**
-     * Default maximum number of report definitions. Equals the maximum to prevent
-     * accidental over-provisioning by default.
-     */
-    private const val DEFAULT_MAX_REPORT_DEFINITIONS_VALUE = MAXIMUM_MAX_REPORT_DEFINITIONS
+    private const val DEFAULT_MAX_REPORT_DEFINITIONS_VALUE = 50
 
     /**
      * Minimum allowed value for the max report definitions setting.
@@ -164,7 +158,6 @@ internal object PluginSettings {
         MAX_REPORT_DEFINITIONS_KEY,
         defaultSettings[MAX_REPORT_DEFINITIONS_KEY]!!.toInt(),
         MINIMUM_MAX_REPORT_DEFINITIONS,
-        MAXIMUM_MAX_REPORT_DEFINITIONS,
         NodeScope,
         Dynamic
     )

--- a/src/test/kotlin/org/opensearch/reportsscheduler/settings/PluginSettingsTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/settings/PluginSettingsTests.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.reportsscheduler.settings
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.opensearch.common.settings.Setting
+import org.opensearch.common.settings.Settings
+
+internal class PluginSettingsTests {
+
+    private val maxReportDefinitionsKey = "plugins.reports.max_report_definitions"
+
+    @Suppress("UNCHECKED_CAST")
+    private fun maxReportDefinitions(): Setting<Int> =
+        PluginSettings.getAllSettings().first { it.key == maxReportDefinitionsKey } as Setting<Int>
+
+    @Test
+    fun `test max report definitions setting is registered`() {
+        Assertions.assertTrue(PluginSettings.getAllSettings().any { it.key == maxReportDefinitionsKey })
+    }
+
+    @Test
+    fun `test max report definitions falls back to its default`() {
+        Assertions.assertEquals(50, maxReportDefinitions().get(Settings.EMPTY))
+    }
+
+    @Test
+    fun `test max report definitions has no upper bound`() {
+        val settings = Settings.builder().put(maxReportDefinitionsKey, 100000).build()
+        Assertions.assertEquals(100000, maxReportDefinitions().get(settings))
+
+        val maxIntSettings = Settings.builder().put(maxReportDefinitionsKey, Int.MAX_VALUE).build()
+        Assertions.assertEquals(Int.MAX_VALUE, maxReportDefinitions().get(maxIntSettings))
+    }
+
+    @Test
+    fun `test max report definitions accepts zero`() {
+        val settings = Settings.builder().put(maxReportDefinitionsKey, 0).build()
+        Assertions.assertEquals(0, maxReportDefinitions().get(settings))
+    }
+
+    @Test
+    fun `test max report definitions rejects negative values`() {
+        val settings = Settings.builder().put(maxReportDefinitionsKey, -1).build()
+        assertThrows<IllegalArgumentException> { maxReportDefinitions().get(settings) }
+    }
+}


### PR DESCRIPTION
## Description

`plugins.reports.max_report_definitions` was declared with a hard-coded upper bound of `50`, and that bound doubled as the setting's default.
CTI team has hit this ceiling. This PR removes the ceiling, so the setting is fully customizable, leaving the default (`50`) and the minimum (`0`) untouched.

Closes https://github.com/wazuh/wazuh-indexer-plugins/issues/1420 *(reporting side)*


## Proposed Changes

- Deleted the private `MAXIMUM_MAX_REPORT_DEFINITIONS` constant and dropped the `max` argument from the `MAX_REPORT_DEFINITIONS` setting declaration.
- `DEFAULT_MAX_REPORT_DEFINITIONS_VALUE` is now a `50` instead of an alias of the deleted maximum, so the default no longer moves with a ceiling that no longer exists.
- `MINIMUM_MAX_REPORT_DEFINITIONS` (`0`) is kept and still passed to `Setting.intSetting`, so negative values remain rejected.
- Values supplied through `reports-scheduler.yml` are no longer capped either, since the plugin seeds the setting's default from that file.


### Results and Evidence

**Unit tests**: `PluginSettingsTests`, 5 tests, 0 failures, 0 errors (all new):

``` console
jorge@jorge-wazuh:~/wazuh/wazuh-indexer-reporting$ ./gradlew test --tests "*settings.PluginSettingsTests*"
...
BUILD SUCCESSFUL in 11s
11 actionable tasks: 4 executed, 7 up-to-date
```

**Testing in a real deploy**:
Before deploying the change, the ceiling was enforced

After deploying:

| Check | Result |
| --- | --- |
| `PUT _cluster/settings` with `100000` | 200, value read back correctly |
| `PUT _cluster/settings` with `-1` | 400 `Failed to parse value [-1] for setting [plugins.reports.max_report_definitions] must be >= 0` |
| Effective default with both scopes nulled | `50` (unchanged) |
| Raise to `55`, create 55 report definitions | all 55 created (old ceiling was 50) |
| Create the 56th definition at limit `55` | 400 `This request would exceed the maximum allowed report definitions [55]` — the limit still bites, at the configured value |

### Artifacts Affected

- `wazuh-indexer-reporting` plugin

### Configuration Changes

| Setting | Before | After |
| --- | --- | --- |
| `plugins.reports.max_report_definitions` | Integer, default `50`, range `0`–`50`, dynamic | Integer, default `50`, minimum `0`, **no upper bound**, dynamic |

- No new settings, no renamed settings, no removed settings.
- Default value unchanged (`50`), minimum unchanged (`0`), scope and dynamism unchanged.

### Documentation Updates

The user-facing settings reference for this plugin lives in the `wazuh-indexer-plugins` repository, so the doc change ships in the companion PR there:

- `docs/ref/modules/reporting/index.md`

### Tests Introduced

Five new cases in a new file, `src/test/kotlin/org/opensearch/reportsscheduler/settings/PluginSettingsTests.kt`:

| Test | Scope |
| --- | --- |
| `test max report definitions setting is registered` | Confirms the setting is still returned by `PluginSettings.getAllSettings()`, so the cluster accepts the key at all. |
| `test max report definitions falls back to its default` | Guards the default against accidental drift now that it is a literal rather than an alias of the deleted maximum. |
| `test max report definitions has no upper bound` | The regression test for this change: asserts `100000` and `Int.MAX_VALUE` both parse. Either would have thrown before. |
| `test max report definitions accepts zero` | Confirms `0` is still valid (creation blocked), i.e. the floor was not moved while removing the ceiling. |
| `test max report definitions rejects negative values` | Confirms `-1` still throws `IllegalArgumentException`, i.e. the minimum is still enforced. |

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...